### PR TITLE
Allow passing encoding to search queries

### DIFF
--- a/lib/clientModules/search.coffee
+++ b/lib/clientModules/search.coffee
@@ -59,13 +59,13 @@ searchRets = (queryOptions) -> Promise.try () =>
 #       Please note that queryType and format are immutable.
 ###
 
-query = (resourceType, classType, queryString, options={}) -> new Promise (resolve, reject) =>
+query = (resourceType, classType, queryString, options={}, parserEncoding='UTF-8') -> new Promise (resolve, reject) =>
   result =
     results: []
     maxRowsExceeded: false
   currEntry = null
 
-  @stream.query(resourceType, classType, queryString, options)
+  @stream.query(resourceType, classType, queryString, options, null, parserEncoding)
   .pipe through2.obj (event, encoding, callback) ->
     switch event.type
       when 'data'

--- a/lib/clientModules/search.stream.coffee
+++ b/lib/clientModules/search.stream.coffee
@@ -63,7 +63,7 @@ searchRets = (queryOptions, headerInfoCallback) -> Promise.try () =>
 #       Please note that queryType and format are immutable.
 ###
 
-query = (resourceType, classType, queryString, options={}, rawData=false) ->
+query = (resourceType, classType, queryString, options={}, rawData=false, parserEncoding='UTF-8') ->
   baseOpts =
     searchType: resourceType
     class: classType
@@ -75,7 +75,7 @@ query = (resourceType, classType, queryString, options={}, rawData=false) ->
   delete queryOptions.format
   finalQueryOptions = queryOptionHelpers.normalizeOptions(queryOptions)
 
-  context = retsParsing.getStreamParser('search', null, rawData)
+  context = retsParsing.getStreamParser('search', null, rawData, parserEncoding)
   retsHttp.streamRetsMethod('search', @retsSession, finalQueryOptions, context.fail, context.response)
   .pipe(context.parser)
   

--- a/lib/utils/retsParsing.coffee
+++ b/lib/utils/retsParsing.coffee
@@ -18,10 +18,10 @@ headersHelper = require('./headers')
 
 
 # a parser with some basic common functionality, intended to be extended for real use
-getSimpleParser = (retsMethod, errCallback, headerInfo) ->
+getSimpleParser = (retsMethod, errCallback, headerInfo, parserEncoding='UTF-8') ->
   result =
     currElementName: null
-    parser: new expat.Parser('UTF-8')
+    parser: new expat.Parser(parserEncoding)
     finish: () ->
       result.parser.removeAllListeners()
     status: null
@@ -52,7 +52,7 @@ getSimpleParser = (retsMethod, errCallback, headerInfo) ->
 
 
 # parser that deals with column/data tags, as returned for metadata and search queries
-getStreamParser = (retsMethod, metadataTag, rawData) ->
+getStreamParser = (retsMethod, metadataTag, rawData, parserEncoding='UTF-8') ->
   if metadataTag
     rawData = false
     result =
@@ -70,7 +70,7 @@ getStreamParser = (retsMethod, metadataTag, rawData) ->
   currElementName = null
   headers = null
 
-  parser = new expat.Parser('UTF-8')
+  parser = new expat.Parser(parserEncoding)
   retsStream = through2.obj()
   finish = (type, payload) ->
     parser.removeAllListeners()


### PR DESCRIPTION
Some RETS feeds have data stored in the ISO-8859-1 encoding format which causes parsing issues when parsing special characters as UTF-8.  This allows the end user to specify the character encoding that the parser should use from the search.stream.query and search.query endpoints.  Defaults to UTF-8.