### PR TITLE
Rebuild RETS-UA-Authorization with sessionId after login

### DIFF
--- a/lib/client.coffee
+++ b/lib/client.coffee
@@ -70,7 +70,7 @@ class Client
   login: () ->
     options =
       uri: @settings.loginUrl
-    auth.login(@baseRetsSession.defaults(options))
+    auth.login(@baseRetsSession.defaults(options), @)
     .then (systemData) =>
       @systemData = systemData
       @urls = {}
@@ -95,6 +95,10 @@ Client.getAutoLogoutClient = (settings, handler) -> Promise.try () ->
   client.login()
   .then () ->
     Promise.try () ->
+      if client.settings.userAgentPassword && client.settings.sessionId
+        a1 = crypto.createHash('md5').update([client.settings.userAgent, client.settings.userAgentPassword].join(":")).digest('hex')
+        retsUaAuth = crypto.createHash('md5').update([a1, "", client.settings.sessionId || "", client.settings.version || client.headers['RETS-Version']].join(":")).digest('hex')
+        client.headers['RETS-UA-Authorization'] = "Digest " + retsUaAuth
       handler(client)
     .finally () ->
       client.logout()

--- a/lib/utils/auth.coffee
+++ b/lib/utils/auth.coffee
@@ -14,10 +14,14 @@ errors = require('./errors')
 # Executes RETS login routine.
 ###
 
-login = (retsSession) ->
+login = (retsSession, client) ->
   retsHttp.callRetsMethod('login', Promise.promisify(retsSession), {})
   .then (retsResponse) -> new Promise (resolve, reject) ->
     headers = headersHelper.processHeaders(retsResponse.response.rawHeaders)
+    if client.settings.userAgentPassword && headers.setCookie
+      matches = headers.setCookie.match(/RETS\-Session\-ID=([^;]+);/)
+      if matches
+        client.settings.sessionId = matches[1]
     systemData =
       retsVersion: headers.retsVersion
       retsServer: headers.server

--- a/lib/utils/auth.coffee
+++ b/lib/utils/auth.coffee
@@ -19,9 +19,16 @@ login = (retsSession, client) ->
   .then (retsResponse) -> new Promise (resolve, reject) ->
     headers = headersHelper.processHeaders(retsResponse.response.rawHeaders)
     if client.settings.userAgentPassword && headers.setCookie
-      matches = headers.setCookie.match(/RETS\-Session\-ID=([^;]+);/)
-      if matches
-        client.settings.sessionId = matches[1]
+      typeIsArray = Array.isArray || ( value ) -> return {}.toString.call( value ) is '[object Array]'
+      if typeIsArray headers.setCookie
+        headerCookies = headers.setCookie
+      else
+        headerCookies = [headers.setCookie];
+      for headerCookie in headerCookies
+        matches = headerCookie.match(/RETS\-Session\-ID=([^;]+);/)
+        if matches
+          client.settings.sessionId = matches[1]
+          break
     systemData =
       retsVersion: headers.retsVersion
       retsServer: headers.server


### PR DESCRIPTION
RETS-UA-Authorization header wasn't being rebuilt after a RETS-Session-ID cookie was returned, resulting in authentication issues on RETS servers that actually validate that header.