### PR TITLE
Pass client to clientModules and use POST as expected

### DIFF
--- a/lib/client.coffee
+++ b/lib/client.coffee
@@ -78,9 +78,9 @@ class Client
         if @systemData[val]
           @urls[val] = normalizeUrl(@systemData[val], @settings.loginUrl)
 
-      @metadata = metadata(@baseRetsSession.defaults(uri: @urls[URL_KEYS.GET_METADATA]))
-      @search = search(@baseRetsSession.defaults(uri: @urls[URL_KEYS.SEARCH]))
-      @objects = object(@baseRetsSession.defaults(uri: @urls[URL_KEYS.GET_OBJECT]))
+      @metadata = metadata(@baseRetsSession.defaults(uri: @urls[URL_KEYS.GET_METADATA]), @)
+      @search = search(@baseRetsSession.defaults(uri: @urls[URL_KEYS.SEARCH]), @)
+      @objects = object(@baseRetsSession.defaults(uri: @urls[URL_KEYS.GET_OBJECT]), @)
       @logoutRequest = @baseRetsSession.defaults uri: @urls[URL_KEYS.LOGOUT]
 
       return @

--- a/lib/clientModules/metadata.coffee
+++ b/lib/clientModules/metadata.coffee
@@ -11,9 +11,9 @@ retsParsing = require('../utils/retsParsing')
 errors = require('../utils/errors')
 
 
-_getMetadataImpl = (retsSession, type, options) -> new Promise (resolve, reject) ->
+_getMetadataImpl = (retsSession, type, options, client) -> new Promise (resolve, reject) ->
   context = retsParsing.getStreamParser('getMetadata', type)
-  retsHttp.streamRetsMethod('getMetadata', retsSession, options, context.fail, context.response)
+  retsHttp.streamRetsMethod('getMetadata', retsSession, options, context.fail, context.response, client)
   .pipe(context.parser)
 
   result =
@@ -117,7 +117,7 @@ getSystem = () ->
     retsParser.parser.end()
 
 
-module.exports = (_retsSession) ->
+module.exports = (_retsSession, _client) ->
   if !_retsSession
     throw new errors.RetsParamError('System data not set; invoke login().')
   
@@ -130,7 +130,7 @@ module.exports = (_retsSession) ->
         Type: type
         ID: if classType then "#{id}:#{classType}" else id
         Format: format
-      _getMetadataImpl(_retsSession, type, options)
+      _getMetadataImpl(_retsSession, type, options, _client)
   
   
   _getParsedAllMetadataFactory = (type, format='COMPACT') ->
@@ -138,10 +138,11 @@ module.exports = (_retsSession) ->
       Type: type
       Id: '0'
       Format: format
-    () -> _getMetadataImpl(_retsSession, type, options)
+    () -> _getMetadataImpl(_retsSession, type, options, _client)
   
   
   retsSession: Promise.promisify(_retsSession)
+  client: _client
   getMetadata: getMetadata
   getSystem: getSystem
   getResources:       _getParsedMetadataFactory('METADATA-RESOURCE').bind(null, '0')

--- a/lib/clientModules/object.coffee
+++ b/lib/clientModules/object.coffee
@@ -133,11 +133,12 @@ getPreferredObjects = (resourceType, objectType, ids, options) ->
   .then _loadStreams
 
 
-module.exports = (_retsSession) ->
+module.exports = (_retsSession, _client) ->
   if !_retsSession
     throw new errors.RetsParamError('System data not set; invoke login().')
   retsSession: _retsSession
+  client: _client
   getObjects: getObjects
   getAllObjects: getAllObjects
   getPreferredObjects: getPreferredObjects
-  stream: require('./object.stream')(_retsSession)
+  stream: require('./object.stream')(_retsSession, _client)

--- a/lib/clientModules/object.stream.coffee
+++ b/lib/clientModules/object.stream.coffee
@@ -149,7 +149,7 @@ getObjects = (resourceType, objectType, ids, _options={}) -> Promise.try () =>
         return
       done = true
       return reject(errors.ensureRetsError('getObject', error))
-    req = retsHttp.streamRetsMethod('getObject', @retsSession, options, fail)
+    req = retsHttp.streamRetsMethod('getObject', @retsSession, options, fail, null, @client)
     req.on('error', fail)
     req.on 'response', (response) ->
       if done
@@ -192,10 +192,11 @@ getPreferredObjects = (resourceType, objectType, ids, options) ->
   @getObjects(resourceType, objectType, _annotateIds(ids, '0'), options)
 
 
-module.exports = (_retsSession) ->
+module.exports = (_retsSession, _client) ->
   if !_retsSession
     throw new errors.RetsParamError('System data not set; invoke login().')
   retsSession: _retsSession
+  client: _client
   getObjects: getObjects
   getAllObjects: getAllObjects
   getPreferredObjects: getPreferredObjects

--- a/lib/clientModules/search.coffee
+++ b/lib/clientModules/search.coffee
@@ -84,10 +84,11 @@ query = (resourceType, classType, queryString, options={}, parserEncoding='UTF-8
     callback()
 
 
-module.exports = (_retsSession) ->
+module.exports = (_retsSession, _client) ->
   if !_retsSession
     throw new errors.RetsParamError('System data not set; invoke login().')
   retsSession: Promise.promisify(_retsSession)
+  client: _client
   searchRets: searchRets
   query: query
-  stream: require('./search.stream')(_retsSession)
+  stream: require('./search.stream')(_retsSession, _client)

--- a/lib/clientModules/search.stream.coffee
+++ b/lib/clientModules/search.stream.coffee
@@ -36,7 +36,7 @@ searchRets = (queryOptions, headerInfoCallback) -> Promise.try () =>
     resultStream.emit('error', err)
   if !headerInfoCallback
     headerInfoCallback = () ->  # noop
-  httpStream = retsHttp.streamRetsMethod 'search', @retsSession, finalQueryOptions, onError, headerInfoCallback
+  httpStream = retsHttp.streamRetsMethod 'search', @retsSession, finalQueryOptions, onError, headerInfoCallback, @client
   httpStream.pipe(resultStream)
 
 
@@ -76,15 +76,16 @@ query = (resourceType, classType, queryString, options={}, rawData=false, parser
   finalQueryOptions = queryOptionHelpers.normalizeOptions(queryOptions)
 
   context = retsParsing.getStreamParser('search', null, rawData, parserEncoding)
-  retsHttp.streamRetsMethod('search', @retsSession, finalQueryOptions, context.fail, context.response)
+  retsHttp.streamRetsMethod('search', @retsSession, finalQueryOptions, context.fail, context.response, @client)
   .pipe(context.parser)
   
   context.retsStream
 
 
-module.exports = (_retsSession) ->
+module.exports = (_retsSession, _client) ->
   if !_retsSession
     throw new errors.RetsParamError('System data not set; invoke login().')
   retsSession: _retsSession
+  client: _client
   query: query
   searchRets: searchRets

--- a/lib/utils/retsHttp.coffee
+++ b/lib/utils/retsHttp.coffee
@@ -27,7 +27,7 @@ callRetsMethod = (methodName, retsSession, queryOptions) ->
     headerInfo: headersHelper.processHeaders(response.rawHeaders)
 
 
-streamRetsMethod = (methodName, retsSession, queryOptions, failCallback, responseCallback) ->
+streamRetsMethod = (methodName, retsSession, queryOptions, failCallback, responseCallback, client) ->
   debug("RETS #{methodName} (streaming)", queryOptions)
   done = false
   errorHandler = (error) ->
@@ -46,7 +46,10 @@ streamRetsMethod = (methodName, retsSession, queryOptions, failCallback, respons
       failCallback(error)
     else if responseCallback
       responseCallback(response)
-  stream = retsSession(qs: queryOptions)
+  if client.settings.method == 'POST'
+    stream = retsSession(form: queryOptions)
+  else
+    stream = retsSession(qs: queryOptions)
   stream.on 'error', errorHandler
   stream.on 'response', responseHandler
 


### PR DESCRIPTION
When the POST method was specified, all query parameters were still being passed via the query string instead of via the POST body. This resulted in issues if you needed to query on a large number of unique listing ids, as the URL length limit could be exceeded.  This changes all query parameters to pass via the POST body.
Also made client available to all the clientModules, which was necessary to read the client settings.