### PR TITLE
Adding error checking to make sure the required endpoints are available

### DIFF
--- a/lib/utils/errors.coffee
+++ b/lib/utils/errors.coffee
@@ -52,6 +52,13 @@ class RetsParamError extends RetsError
     @name = 'RetsParamError'
     Error.captureStackTrace(this, RetsParamError)
 
+class RetsPermissionError extends RetsError
+  constructor: (missing = []) ->
+    @name = 'RetsPermissionError'
+    @message = "Login was successful, but this account does not have the proper permissions."
+    if missing.length
+      @message += " Missing the following permissions: #{missing.join(', ')}"
+    Error.captureStackTrace(this, RetsPermissionError)
 
 ensureRetsError = (retsMethod, error, headerInfo) ->
   if error instanceof RetsError
@@ -66,6 +73,7 @@ module.exports = {
   RetsServerError
   RetsProcessingError
   RetsParamError
+  RetsPermissionError
   ensureRetsError
   getErrorMessage
 }


### PR DESCRIPTION
Should resolve the less than helpful error shown in Issue #38 by providing a more useful RetsPermissionError exception detailing what permissions are missing.