### PR TITLE
Ignore count write when stream ended from NO_RECORDS_FOUND (20201) error

### DIFF
--- a/lib/utils/retsParsing.coffee
+++ b/lib/utils/retsParsing.coffee
@@ -110,6 +110,9 @@ getStreamParser = (retsMethod, metadataTag, rawData, parserEncoding='UTF-8') ->
           writeOutput('metadataStart', attrs)
           result.rowsReceived = 0
         when 'COUNT'
+          ### Ignore count write when stream ended due to NO_RECORDS_FOUND (20201) error. ###
+          if !retsStream.writable && parseInt(attrs.Records) == 0
+            return false
           writeOutput('count', parseInt(attrs.Records))
         when 'MAXROWS'
           result.maxRowsExceeded = true


### PR DESCRIPTION
Using the stream example as reference, if a NO_RECORDS_FOUND error is encountered the stream/promise is closed/resolved, and then a COUNT attempts to write to the closed stream which throws a difficult to catch Exception as the promise chain was already rejected/resolved.

This fixes that issue by not writing to the stream if the stream isn't writable and the number of results was 0.

Example of error object:
```
{ RetsPermissionError: Login was successful, but this account does not have the proper permissions. Missing the following permissions: GetMetadata, Search, GetObject
    at [removed]/node_modules/rets-client/dist/client.js:134:19
    at runCallback (timers.js:566:20)
    at tryOnImmediate (timers.js:546:5)
    at processImmediate [as _immediateCallback] (timers.js:525:5)
From previous event:
    at Client.login ([removed]/node_modules/rets-client/dist/client.js:93:71)
    at [removed]/node_modules/rets-client/dist/client.js:153:21
From previous event:
    at Object.Client.getAutoLogoutClient ([removed]/node_modules/rets-client/dist/client.js:150:26)
    at Object.<anonymous> ([removed]/scripts/rets-test.js:6:6)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.runMain (module.js:575:10)
    at run (bootstrap_node.js:352:7)
    at startup (bootstrap_node.js:144:9)
    at bootstrap_node.js:467:3
  name: 'RetsPermissionError',
  message: 'Login was successful, but this account does not have the proper permissions. Missing the following permissions: GetMetadata, Search, GetObject' }
```