### PR TITLE
Fix getObject issues

### DIFF
--- a/lib/clientModules/object.stream.coffee
+++ b/lib/clientModules/object.stream.coffee
@@ -145,8 +145,6 @@ getObjects = (resourceType, objectType, ids, _options={}) -> Promise.try () =>
   new Promise (resolve, reject) =>
     done = false
     fail = (error) ->
-      if done
-        return
       done = true
       return reject(errors.ensureRetsError('getObject', error))
     req = retsHttp.streamRetsMethod('getObject', @retsSession, options, fail, null, @client)

--- a/lib/utils/retsHttp.coffee
+++ b/lib/utils/retsHttp.coffee
@@ -46,10 +46,14 @@ streamRetsMethod = (methodName, retsSession, queryOptions, failCallback, respons
       failCallback(error)
     else if responseCallback
       responseCallback(response)
+  request = {}
   if client.settings.method == 'POST'
-    stream = retsSession(form: queryOptions)
+    request.form = queryOptions
   else
-    stream = retsSession(qs: queryOptions)
+    request.qs = queryOptions
+  if methodName == 'getObject'
+    request.headers = { Accept: 'text/xml' }
+  stream = retsSession(request)
   stream.on 'error', errorHandler
   stream.on 'response', responseHandler
 

--- a/lib/utils/retsHttp.coffee
+++ b/lib/utils/retsHttp.coffee
@@ -52,7 +52,7 @@ streamRetsMethod = (methodName, retsSession, queryOptions, failCallback, respons
   else
     request.qs = queryOptions
   if methodName == 'getObject'
-    request.headers = { Accept: 'text/xml' }
+    request.headers = { Accept: '*/*' }
   stream = retsSession(request)
   stream.on 'error', errorHandler
   stream.on 'response', responseHandler


### PR DESCRIPTION
Pass missing Accept header when doing a getObject request.  Resolved #15 
Removed done and return check that was resulting in promises never resolving when an error was encountered but done was set.  I was getting this when there was a "RETS Server: Data has not changed since last request" error.  Resolves #41 