### PR TITLE
Trim spaces from endpoint keys and URLs

### DIFF
--- a/lib/utils/auth.coffee
+++ b/lib/utils/auth.coffee
@@ -44,7 +44,7 @@ login = (retsSession, client) ->
       for keyVal in keyVals
         split = keyVal.split('=')
         if split.length > 1
-          systemData[split[0]] = split[1]
+          systemData[split[0].trim()] = split[1].trim()
 
     retsParser.parser.on 'endElement', (name) ->
       if name != 'RETS'


### PR DESCRIPTION
Trim spaces from keys and endpoint URLs.

Fixes issues when feeds return system data with spaces before/after the equal sign like this:
```
<?xml version="1.0"  encoding="ISO-8859-1"?>
<RETS ReplyCode="0" ReplyText="You have been logged into the rets server." >
<RETS-RESPONSE>
MemberName = [removed]
User = [removed]
Broker = [removed],RETS
MetadataVersion = 0.0.1
MinMetadataVersion = 0.0.1
MetadataTimestamp = Wed, 03 Aug 2016 13:59:49 GMT
MinMetadataTimestamp = Wed, 03 Aug 2016 12:59:49 GMT
GetObject = http://[removed]/GetObject.aspx
Login = http://[removed]/Login.aspx
GetMetadata = http://[removed]/GetMetadata.aspx
Logout = http://[removed]/Logout.aspx
Search = http://[removed]/Search.aspx
</RETS-RESPONSE>
</RETS>
```