### PR TITLE
Remap query params to UpperCamelCase for searches

### DIFF
--- a/lib/utils/queryOptions.coffee
+++ b/lib/utils/queryOptions.coffee
@@ -30,6 +30,14 @@ _queryOptionsDefaults =
   restrictedIndicator: '***'
   limit: 'NONE'
 
+capitalizeFirstLetter = (string) ->
+  string.charAt(0).toUpperCase() + string.slice(1);
+
+remapKeys = (obj) ->
+  result = {}
+  for key, value of obj
+    result[capitalizeFirstLetter(key)] = value
+  result
 
 normalizeOptions = (queryOptions) ->
   if !queryOptions
@@ -40,7 +48,8 @@ normalizeOptions = (queryOptions) ->
     throw errors.RetsProcessingError('search', 'class is required (ex: RESI)')
   if !queryOptions.query
     throw errors.RetsProcessingError('search', 'query is required (ex: (MatrixModifiedDT=2014-01-01T00:00:00.000+) )')
-  mergeOptions(queryOptions, _queryOptionsDefaults)
+  remapKeys(mergeOptions(queryOptions, _queryOptionsDefaults))
+
 
 
 module.exports =


### PR DESCRIPTION
This will remap the camelCase fields to UpperCamelCase just before sending the query to prevent any issues with backwards compatibility.

From the spec, it looks like we've been sending params improperly, and I ran into an issue where one of our feeds was case sensitive for parameters.  We've been running this change with 30+ different RETS feeds for over a week without any issues.  PHRETS sends its query parameters in this format.
Reference: https://github.com/troydavisson/PHRETS/blob/master/src/Session.php#L270
