### PR TITLE
Don't add listener if an error was encountered

### DIFF
--- a/lib/utils/retsParsing.coffee
+++ b/lib/utils/retsParsing.coffee
@@ -98,7 +98,9 @@ getStreamParser = (retsMethod, metadataTag, rawData, parserEncoding='UTF-8') ->
     if name != 'RETS'
       return fail(new errors.RetsProcessingError(retsMethod, 'Unexpected results. Please check the RETS URL.', headers))
     processStatus(attrs)
-  
+    if !retsStream.writable
+      # assume processStatus found a non-zero/20208 error code and ended the stream  So, we don't want to add the startElement listener.
+      return
     parser.on 'startElement', (name, attrs) ->
       currElementName = name
       switch name


### PR DESCRIPTION
We were seeing issues where it the client would call a second processStatus and attempt to write to a closed stream.  The first processStatus would remove the listeners, and then after it returned it would add the parser.on startElement listener, which would try to run through data even though the retsStream was ended.

The result was a potential uncatchable error depending on when promises resolved.