### PR TITLE
Allow tunneling when using a proxy

### DIFF
--- a/lib/client.coffee
+++ b/lib/client.coffee
@@ -63,6 +63,8 @@ class Client
 
     if @settings.proxyUrl
       defaults.proxy = @settings.proxyUrl
+      if @settings.useTunnel
+        defaults.tunnel = @settings.useTunnel
     
     @baseRetsSession = request.defaults defaults
 


### PR DESCRIPTION
This allows enabling of tunneling when using a proxy.

We were seeing a lot of issues with dropped connections "Unexpected end of xml stream" when using a proxy.

We also had an issue with several RETS providers that wouldn't properly authenticate when using digest authentication through a proxy.
It appears request.js passes the full URL as part of the digest when proxying instead of just the path which is what the RETS provider was expecting (Probably an issue with the RETS providers implementation of digest validation).  Tunneling through the proxy with request.js only uses the path instead of the full URL, so this resolved that issue.

Relevant request.js code:
```
  if (self.proxy && !self.tunnel) {
    self.path = (self.uri.protocol + '//' + self.uri.host + self.path)
  }
```

This seems to fix both of these issues.