### PR TITLE
Check for a headerInfo.location value instead of text/xml contentType

### DIFF
--- a/lib/clientModules/object.stream.coffee
+++ b/lib/clientModules/object.stream.coffee
@@ -22,7 +22,7 @@ _processBody = (headers, bodyStream, preDecoded, options) -> new Promise (resolv
   headerInfo = headersHelper.processHeaders(headers)
   onError = (error) ->
     reject(errors.ensureRetsError('getObject', error, headerInfo))
-  if _insensitiveStartsWith(headerInfo.contentType, 'text/xml') && options.Location == 1
+  if headerInfo.location && options.Location == 1
     resolve
       headerInfo: headerInfo
   else if _insensitiveStartsWith(headerInfo.contentType, 'text/xml')


### PR DESCRIPTION
This will allow object stream to parse the data if the location header isn't set, this way it'll throw errors properly if the RETS provider does not support Location=1.

Example error that will now be thrown properly instead of just returning a bunch of non-useful headers.
```
RETS Server reply while attempting getObject - ReplyCode 20413 (MISC_ERROR); ReplyText: Location=1 is disabled
```