### PR TITLE
don't throw error if GetObject URL is missing

### DIFF
--- a/lib/client.coffee
+++ b/lib/client.coffee
@@ -93,9 +93,6 @@ class Client
         missingPermissions.push URL_KEYS.SEARCH
       if @urls[URL_KEYS.GET_OBJECT]
         @objects = object(@baseRetsSession.defaults(uri: @urls[URL_KEYS.GET_OBJECT]), @)
-      else
-        hasPermissions = false
-        missingPermissions.push URL_KEYS.GET_OBJECT
       @logoutRequest = Promise.promisify(@baseRetsSession.defaults(uri: @urls[URL_KEYS.LOGOUT]))
       if !hasPermissions
         throw new errors.RetsPermissionError(missingPermissions)


### PR DESCRIPTION
Here's the PR for #68. As mentioned, it's pretty naive so feel free to close it if it's not to your liking.

Just thought I'd put it up so you have a quick resolution.
