### PR TITLE
Handle unexpectedly ended multipart streams

### DIFF
--- a/lib/utils/multipart.coffee
+++ b/lib/utils/multipart.coffee
@@ -123,6 +123,8 @@ getObjectStream = (retsContext, handler) -> new Promise (resolve, reject) ->
     debug("stream flush")
     err = parser.end()
     if err
+      done = true
+      partDone = true
       handleError(new errors.RetsProcessingError(retsContext, "Unexpected end of data: #{errors.getErrorMessage(err)}"))
     flushed = true
     handleEnd()


### PR DESCRIPTION
References:
https://github.com/felixge/node-formidable/blob/master/lib/multipart_parser.js#L323-L324
https://github.com/sbruno81/rets-client/blob/master/lib/utils/multipart.coffee#L124

the onEnd and onPartEnd call aren't being executed when an error is encountered when calling `parser.end()` this results in the done and partDone values not being set to true as they should be.

Resolves #79 