### PR TITLE
Removed invalid crypto dependency as it's built into nodejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "base64-stream": "^0.1.3",
     "bluebird": "^2.9.25",
     "bufferstream": "^0.6.2",
-    "crypto": "0.0.3",
     "debug": "^2.2.0",
     "formidable": "~1.0.15",
     "node-expat": "^2.3.10",


### PR DESCRIPTION
REF: https://www.npmjs.com/package/crypto

Console shows the following during `npm install`:
`npm WARN deprecated crypto@0.0.3: This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.`