### PR TITLE
Allow COMPACT and COMPACT-DECODED as formats

### DIFF
--- a/lib/clientModules/search.stream.coffee
+++ b/lib/clientModules/search.stream.coffee
@@ -70,7 +70,8 @@ query = (resourceType, classType, queryString, _options={}, rawData=false, parse
 
   # make sure queryType and format will use the searchRets defaults
   delete mainOptions.queryType
-  delete mainOptions.format
+  if mainOptions.format != 'COMPACT-DECODED' && mainOptions.format != 'COMPACT'
+    delete mainOptions.format
   queryOptions = queryOptionHelpers.normalizeOptions(mainOptions)
 
   retsContext = retsParsing.getStreamParser({retsMethod: 'search', queryOptions}, null, rawData, parserEncoding)


### PR DESCRIPTION
Previously it would always default to COMPACT-DECODED which can be slower on some feeds than COMPACT when you aren't returning any lookup fields.