### PR TITLE
Allow overriding the timeout setting that gets passed to the request object

### DIFF
--- a/lib/client.coffee
+++ b/lib/client.coffee
@@ -60,6 +60,9 @@ class Client
         'user': @settings.username
         'pass': @settings.password
         'sendImmediately': false
+    
+    if @settings.timeout
+      defaults.timeout = @settings.timeout
 
     if @settings.proxyUrl
       defaults.proxy = @settings.proxyUrl


### PR DESCRIPTION
We were seeing issues where things weren't timing out properly when a feed was recently having network issues, passing a timeout value instead of relying on whatever node decides to use seems to help with the issue.