### PR TITLE
Removed deprecated crypto package in favor of the the version bundled…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 #ignore node_modules
 node_modules
+package-lock.json
 
 #ignore integration test configs
 testconfig.json

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "base64-stream": "^0.1.3",
     "bluebird": "^2.9.25",
     "bufferstream": "^0.6.2",
-    "crypto": "0.0.3",
     "debug": "^2.2.0",
     "formidable": "~1.0.15",
     "node-expat": "^2.3.10",
@@ -22,7 +21,7 @@
     "@types/mocha": "^2.2.43",
     "@types/node": "^8.0.31",
     "chai": "^4.1.2",
-    "coffee-script": "^1.8.0",
+    "coffeescript": "^1.8.0",
     "mocha": "^3.5.3",
     "source-map-support": "^0.4.18",
     "ts-node": "^3.3.0",
@@ -36,7 +35,7 @@
   "scripts": {
     "pretest": "coffee --compile --output dist/ lib/ && tsc --noEmit",
     "test": "node_modules/mocha/bin/_mocha --compilers ts-node/register test/*.ts",
-    "prepublish": "npm run test",
+    "prepare": "npm run test",
     "dev": "coffee --watch --output dist lib/"
   },
   "repository": {


### PR DESCRIPTION
Hoping this will help with #77 

Removed deprecated crypto package in favor of the version bundled with node.
Updated the coffeescript dependency to the correct version without the dash.
Replaced the prepublish script with prepare.
