### PR TITLE
Bugfix - NormalizeUrl was overriding alternate hosts for api endpoints

### DIFF
--- a/lib/utils/normalizeUrl.coffee
+++ b/lib/utils/normalizeUrl.coffee
@@ -9,7 +9,7 @@ urlUtil = require('url')
 normalizeUrl = (targetUrl, fullUrl) ->
   loginUrlObj = urlUtil.parse(fullUrl, true, true)
   targetUrlObj = urlUtil.parse(targetUrl, true, true)
-  if targetUrlObj.host == loginUrlObj.host
+  if targetUrlObj.host !== null
     return targetUrl
   fixedUrlObj =
     protocol: loginUrlObj.protocol


### PR DESCRIPTION
Possible fix for #105 
