### PR TITLE
Bump formidable dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bluebird": "^2.9.25",
     "bufferstream": "^0.6.2",
     "debug": "^2.2.0",
-    "formidable": "~1.0.15",
+    "formidable": "~1.1.1",
     "node-expat": "^2.3.10",
     "request": "^2.55.0",
     "request-debug": "^0.2.0",


### PR DESCRIPTION
After upgrading Node from 6.x to 10.x, getObject began to throw the following error:
"Error while processing RETS response for getObject - Buffer.write(string, encoding, offset[, length]) is no longer supported"

This error can be traced back to formidable, which has resolved the issue in 1.1.1.